### PR TITLE
token revocation init

### DIFF
--- a/auth-server/build.gradle
+++ b/auth-server/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     implementation 'io.netty:netty-all:4.1.72.Final'
+    implementation 'com.auth0:java-jwt:3.18.2'
+    implementation 'org.json:json:20211205'
 }
 
 test {

--- a/auth-server/src/main/java/pl/edu/agh/dp/tkgk/oauth2server/MainChannelInitializer.java
+++ b/auth-server/src/main/java/pl/edu/agh/dp/tkgk/oauth2server/MainChannelInitializer.java
@@ -7,6 +7,7 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.ssl.SslContext;
 import pl.edu.agh.dp.tkgk.oauth2server.pong.PingHandler;
+import pl.edu.agh.dp.tkgk.oauth2server.tokenrevocation.TokenRevocationRequestValidator;
 
 import java.util.HashMap;
 
@@ -20,6 +21,10 @@ public class MainChannelInitializer extends ChannelInitializer<Channel> {
 
     private HashMap<String, Handler> buildEndpointHandlerMap(){
         HashMap<String, Handler> endpointHandlerMap = new HashMap<>();
+
+        // Token Revocation
+        Handler tokenRevocationRequestValidator = new TokenRevocationRequestValidator();
+        endpointHandlerMap.put("/revoke", tokenRevocationRequestValidator);
 
         // Ping
         Handler pingHandler = new PingHandler();

--- a/auth-server/src/main/java/pl/edu/agh/dp/tkgk/oauth2server/database/AuthorizationDatabaseFacade.java
+++ b/auth-server/src/main/java/pl/edu/agh/dp/tkgk/oauth2server/database/AuthorizationDatabaseFacade.java
@@ -4,6 +4,12 @@ class AuthorizationDatabaseFacade implements Database{
 
     private AuthorizationDatabaseFacade(){}
 
+    @Override
+    public boolean revokeAccessToken() { return true; }
+
+    @Override
+    public boolean revokeRefreshToken() { return true; }
+
     private static class AuthorizationDatabaseFacadeHolder{
         private static final AuthorizationDatabaseFacade database = new AuthorizationDatabaseFacade();
     }

--- a/auth-server/src/main/java/pl/edu/agh/dp/tkgk/oauth2server/database/Database.java
+++ b/auth-server/src/main/java/pl/edu/agh/dp/tkgk/oauth2server/database/Database.java
@@ -2,6 +2,13 @@ package pl.edu.agh.dp.tkgk.oauth2server.database;
 
 public interface Database {
 
+    /**
+     * @return true if access token was revoked
+     */
+    boolean revokeAccessToken();
 
-
+    /**
+     * @return true if refresh token was revoked
+     */
+    boolean revokeRefreshToken();
 }

--- a/auth-server/src/main/java/pl/edu/agh/dp/tkgk/oauth2server/database/MockAuthorizationDatabaseFacade.java
+++ b/auth-server/src/main/java/pl/edu/agh/dp/tkgk/oauth2server/database/MockAuthorizationDatabaseFacade.java
@@ -12,4 +12,18 @@ class MockAuthorizationDatabaseFacade implements Database{
         return MockAuthorizationDatabaseFacadeHolder.database;
     }
 
+    @Override
+    public boolean revokeAccessToken() {
+        // RFC7009 says that we MAY revoke all refresh tokens assigned to the same authorization grant
+        return true;
+    }
+
+    @Override
+    public boolean revokeRefreshToken() {
+        // after revoking refresh token revoke all access tokens with the same authorization grant
+        revokeAllAccessTokensWithGivenGrant();
+        return true;
+    }
+
+    public void revokeAllAccessTokensWithGivenGrant() {}
 }

--- a/auth-server/src/main/java/pl/edu/agh/dp/tkgk/oauth2server/tokenrevocation/TokenRevocationRequestValidator.java
+++ b/auth-server/src/main/java/pl/edu/agh/dp/tkgk/oauth2server/tokenrevocation/TokenRevocationRequestValidator.java
@@ -1,0 +1,158 @@
+package pl.edu.agh.dp.tkgk.oauth2server.tokenrevocation;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.JWTVerifier;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.multipart.Attribute;
+import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData;
+import org.json.JSONObject;
+import pl.edu.agh.dp.tkgk.oauth2server.BaseHandler;
+import pl.edu.agh.dp.tkgk.oauth2server.database.AuthorizationDatabaseProvider;
+import pl.edu.agh.dp.tkgk.oauth2server.database.Database;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+public class TokenRevocationRequestValidator extends BaseHandler {
+
+    private static final String CORRECT_CONTENT_TYPE = "application/x-www-form-urlencoded";
+    private static final String INVALID_REQUEST = "invalid_request";
+    private static final String ACCESS_TOKEN = "access_token";
+    private static final String TOKEN_TYPE_HINT = "token_type_hint";
+
+    // todo: change the way the secret for HS256 is stored
+    private static final String SECRET = "ultra-secret-key-that-is-at-least-32-bits-long-for-hs256-algorithm-top-secret";
+
+    private String tokenString;
+    private String tokenHint;
+
+    private DecodedJWT tokenFromString;
+
+    @Override
+    public FullHttpResponse handle(FullHttpRequest request) {
+        if (!requestValid(request)) {
+            return badRequestHttpResponse();
+        }
+
+        // todo: check if the token is assigned to the user that sent it to be revoked -> if it is not the user's token
+        // then the revocation request should be refused
+        decodeTokenString();
+        revokeToken();
+
+        // RFC7009 says that the error response with code 503 with error : unsupported_token_type is used only if the
+        // authorization server can't handle the token revocation for a specific token type (refresh or access token)
+        // or if this operation is unavailable for some time
+
+        return tokenRevokedSuccessfully();
+    }
+
+    private void decodeTokenString() {
+        try {
+            Algorithm algorithm = Algorithm.HMAC256(SECRET);
+            JWTVerifier verifier = JWT.require(algorithm)
+                    .build();
+            tokenFromString = verifier.verify(tokenString);
+        } catch (JWTVerificationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // todo: how to store tokens in the db?
+    // even if the token was invalid (but not of the type that is not handled by this server) and finally we dont
+    // invalidate any of the tokens stored in the db it's no problem and we return response with 200 status code
+    private void revokeToken() {
+        Database database = AuthorizationDatabaseProvider.getInstance();
+
+        // if token hint tells that token is an access token, then try to remove it from the access token collection
+        // otherwise try to remove it from refresh token collection as the hint was invalid
+        // this method may look bad, but it saves some time on db operations if the hint was correct
+        if (Objects.equals(tokenHint, ACCESS_TOKEN)) {
+            if (!database.revokeAccessToken()) {
+                database.revokeRefreshToken();
+            }
+        }
+
+        // if tokenHint == refresh_token or tokenHint was not present in the request's body
+        else {
+            if (!database.revokeRefreshToken()) {
+                database.revokeAccessToken();
+            }
+        }
+    }
+
+    private FullHttpResponse tokenRevokedSuccessfully() {
+        return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+    }
+
+    private boolean requestValid(FullHttpRequest request) {
+        return validRequestMethod(request)
+                && validContentType(request)
+                && hasToken(request);
+    }
+
+    private boolean validRequestMethod(FullHttpRequest request) {
+        HttpMethod method = request.method();
+        return method.equals(HttpMethod.POST);
+    }
+
+    private boolean validContentType(FullHttpRequest request) {
+        HttpHeaders headers = request.headers();
+        String contentType = headers.get(HttpHeaderNames.CONTENT_TYPE);
+        return Objects.equals(contentType, CORRECT_CONTENT_TYPE);
+    }
+
+    private boolean hasToken(FullHttpRequest request) {
+        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(request);
+        InterfaceHttpData tokenData = decoder.getBodyHttpData("token");
+        if (tokenData == null) return false;
+
+        // if there is a token in the request's body - take it and check if there is a token type hint
+        fetchToken(tokenData);
+        checkForTokenHint(decoder);
+
+        return true;
+    }
+
+    private void checkForTokenHint(HttpPostRequestDecoder decoder) {
+        InterfaceHttpData tokenHintData = decoder.getBodyHttpData(TOKEN_TYPE_HINT);
+        if (tokenHintData != null) {
+            if (tokenHintData.getHttpDataType() == InterfaceHttpData.HttpDataType.Attribute) {
+                Attribute tokenHintAttribute = (Attribute) tokenHintData;
+                try {
+                    tokenHint = tokenHintAttribute.getString(StandardCharsets.UTF_8);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private void fetchToken(InterfaceHttpData tokenData) {
+        if (tokenData.getHttpDataType() == InterfaceHttpData.HttpDataType.Attribute) {
+            Attribute tokenAttribute = (Attribute) tokenData;
+            try {
+                tokenString = tokenAttribute.getString(StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private FullHttpResponse badRequestHttpResponse() {
+        JSONObject json = new JSONObject();
+        json.put("error", INVALID_REQUEST);
+
+        ByteBuf content = Unpooled.copiedBuffer(json.toString(), StandardCharsets.UTF_8);
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST, content);
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
+        return response;
+    }
+}


### PR DESCRIPTION
# Why & What

token revocation init

# How

jedna klasa TokenRevocationRequestValidator, ale na razie tam jest tak jakby cały proces token revocation, w późniejszej wersji się to rozłoży na może jeszcze jedną dodatkową klasę. Dołożyłem tą bilbiotekę do jwt, która jest w naszej dokumentacji i org.json do obsługi jsona, bo jest w miarę prosta i czytelna. Ciężko mi było w niektórych miejscach to zrobić dokładniej/bardziej szczegółowo, bo parę rzeczy byśmy musieli w 4-kę ustalić (np. jaki algorytm kodowania do jwt, w jaki sposób przechowywać tokeny w db, jak mają być zbudowane access i refresh tokeny u nas itp.),ale jak na razie to przynajmniej jest w miarę ogarnięte.
